### PR TITLE
Add Flashlight Control

### DIFF
--- a/Sources/Control/Flashlight.swift
+++ b/Sources/Control/Flashlight.swift
@@ -1,0 +1,65 @@
+//
+//  Flashlight.swift
+//  ControlKit
+//
+
+import AVFoundation
+import OSLog
+
+extension Control {
+    
+    /// 🔦 Control the device's flashlight.
+    public enum Flashlight {}
+}
+
+extension Control.Flashlight {
+    
+    /// Indicates whether the device's flashlight is currently turned on.
+    ///
+    /// - Returns: A Boolean value indicating the flashlight state. Returns `true` if the flashlight is on, otherwise `false`.
+    public static var isOn: Bool {
+        (deviceWithFlashlight?.torchLevel ?? 0) > 0
+    }
+    
+    /// Toggles the device's flashlight on/off.
+    ///
+    /// - Parameter isOn: A Boolean value to specify the desired state of the flashlight.
+    /// Pass `true` to turn it on or `false` to turn it off.
+    ///                   If no value is provided, the flashlight toggles its current state.
+    /// - Important: The flashlight can only be used while the app is in the foreground.
+    /// If the flashlight is on and the app is backgrounded, the flashlight will turn off.
+    /// - Note: If the device does not have a flashlight, this method does nothing.
+    public static func toggle( _ isOn: Bool = !isOn) {
+        guard let deviceWithFlashlight else {
+            return
+        }
+        do {
+            try deviceWithFlashlight.lockForConfiguration()
+            if isOn {
+                try deviceWithFlashlight.setTorchModeOn(level: AVCaptureDevice.maxAvailableTorchLevel)
+            } else {
+                deviceWithFlashlight.torchMode = .off
+            }
+            deviceWithFlashlight.unlockForConfiguration()
+        } catch {
+            log.error("Error toggling flashlight: \(error.localizedDescription) to \(isOn ? "on" : "off")")
+        }
+    }
+    
+    private static var deviceWithFlashlight: AVCaptureDevice? {
+        guard
+            let device = AVCaptureDevice.default(for: .video),
+            device.hasTorch
+        else {
+            #if targetEnvironment(simulator)
+            log.info("Simulator does not have a flashlight (yet)")
+            #else
+            log.info("Flashlight (torch) not available")
+            #endif
+            return nil
+        }
+        return device
+    }
+    
+    private static let log = Logger(subsystem: Control.subsystem, category: "Flashlight")
+}

--- a/Sources/Control/Flashlight.swift
+++ b/Sources/Control/Flashlight.swift
@@ -46,6 +46,16 @@ extension Control.Flashlight {
         }
     }
     
+    public static func blink(count: Int = 1, interval: TimeInterval = 0.1) {
+        Task {
+            for _ in 0..<count {
+                toggle()
+                try? await Task.sleep(nanoseconds: UInt64(1e+9 * interval))
+                toggle()
+            }
+        }
+    }
+    
     private static var deviceWithFlashlight: AVCaptureDevice? {
         guard
             let device = AVCaptureDevice.default(for: .video),


### PR DESCRIPTION
## Overview

- Resolves #7 
- Add toggle on/off method with default parameter set to toggle current state
- Call this method from anywhere, no permissions required 🤠
- App must be in foreground for `AVCaptureDevice` access 🙄
- **Flashlight turns off** if on when app is backgrounded

## Testing

- Verified with iPhone 13 mini - iOS 18.0 ✅